### PR TITLE
カスタムルールのコンパイル後にprettierでフォーマットする

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,7 +8,7 @@ import eslintCustomRulesPlugin from './settings/rules/index.js';
 
 export default withNuxt([
   {
-    ignores: ['.cz-config.cts', 'prettier.config.mjs', 'settings/rules/**/*'],
+    ignores: ['.cz-config.cts'],
     languageOptions: {
       parser: vueEslintParser,
       parserOptions: {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "nuxt build",
-    "build:custom-lint": "tsc --project settings/rules/tsconfig.json",
+    "build:custom-rule": "pnpm custom-rule:tsc && pnpm custom-rule:format",
     "dev": "nuxt dev -o",
     "test": "vitest",
     "test:ui": "vitest --ui --coverage",
@@ -12,6 +12,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "lint:rules": "npx @eslint/config-inspector@latest",
+    "custom-rule:tsc": "tsc --project settings/rules/tsconfig.json",
+    "custom-rule:format": "prettier --write settings/rules/dist/**",
     "format:check": "prettier . --check",
     "format:fix": "prettier . --write",
     "lint-and-format": "pnpm lint:fix && pnpm format:fix",

--- a/settings/rules/dist/helpers/astHelpers.js
+++ b/settings/rules/dist/helpers/astHelpers.js
@@ -1,6 +1,6 @@
-import { addToList } from '../utils/arrayUtils.js';
-import { COMPOSABLES_FUNCTION_PATTERN, REACTIVE_FUNCTIONS } from '../constants/constant.js';
 import { TSESTree } from '@typescript-eslint/utils';
+import { COMPOSABLES_FUNCTION_PATTERN, REACTIVE_FUNCTIONS } from '../constants/constant.js';
+import { addToList } from '../utils/arrayUtils.js';
 const { AST_NODE_TYPES } = TSESTree;
 function isNodeOfType(node, type) {
   return node !== undefined && node !== null && node.type === type;

--- a/settings/rules/src/helpers/astHelpers.ts
+++ b/settings/rules/src/helpers/astHelpers.ts
@@ -1,6 +1,6 @@
-import { addToList } from '../utils/arrayUtils.js';
-import { COMPOSABLES_FUNCTION_PATTERN, REACTIVE_FUNCTIONS } from '../constants/constant.js';
 import { TSESTree } from '@typescript-eslint/utils';
+import { COMPOSABLES_FUNCTION_PATTERN, REACTIVE_FUNCTIONS } from '../constants/constant.js';
+import { addToList } from '../utils/arrayUtils.js';
 import type {
   Node,
   ArrowFunctionExpression,

--- a/settings/rules/src/store-state-suffix.ts
+++ b/settings/rules/src/store-state-suffix.ts
@@ -4,7 +4,6 @@
 
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
-import type { TSESLint } from '@typescript-eslint/utils';
 import {
   isStoreToRefsCall,
   hasStateNameWithoutStateSuffix,
@@ -14,6 +13,7 @@ import {
   isObjectPattern,
 } from './helpers/astHelpers.js';
 import type { VariableDeclarator, Property, Node } from './types/eslint.js';
+import type { TSESLint } from '@typescript-eslint/utils';
 
 type MessageId = 'requireStateSuffix';
 type RuleModule = TSESLint.RuleModule<MessageId>;


### PR DESCRIPTION
close #80 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- TypeScriptコンパイルとフォーマット用のカスタムルールスクリプトを追加しました。
- **バグ修正**
	- ESLintの無視設定を更新し、特定のファイルを無視するようにしました。
- **ドキュメンテーション**
	- スクリプト名を`build:custom-lint`から`build:custom-rule`に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->