### PR TITLE
:construction_worker: ci: draftの時にCIが走らないようにする

### DIFF
--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -6,7 +6,9 @@ on:
       - main
     types:
       - opened
+      - reopened
       - synchronize
+      - ready_for_review
   workflow_dispatch:
 
 env:
@@ -15,6 +17,7 @@ env:
 
 jobs:
   type-check:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code


### PR DESCRIPTION
ISSUES CLOSED: #83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - プルリクエストのイベントトリガーに「再オープン」と「レビュー準備完了」が追加されました。
  
- **改善**
  - プルリクエストがドラフト状態でない場合のみ、型チェックジョブが実行される条件が追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->