### PR TITLE
type参照のみのimport文を分ける

### DIFF
--- a/settings/test/data/convert.spec.ts
+++ b/settings/test/data/convert.spec.ts
@@ -1,20 +1,20 @@
 import { describe, it, expect, vi } from 'vitest';
-import { updateStoreListData } from '../../data/convert';
-import { updateGetterValues } from '../../data/updateGetterValues';
-import { updateStateValues } from '../../data/updateStateValues';
-import { logMessage } from '../../data/utils/logger';
 import type { MockedFunction } from 'vitest';
+import { updateStoreListData } from '~~/settings/data/convert';
+import { updateGetterValues } from '~~/settings/data/updateGetterValues';
+import { updateStateValues } from '~~/settings/data/updateStateValues';
+import { logMessage } from '~~/settings/data/utils/logger';
 
 // モジュールのモックを設定します
-vi.mock('../../data/updateGetterValues', () => ({
+vi.mock('~~/settings/data/updateGetterValues', () => ({
   updateGetterValues: vi.fn(),
 }));
 
-vi.mock('../../data/updateStateValues', () => ({
+vi.mock('~~/settings/data/updateStateValues', () => ({
   updateStateValues: vi.fn(),
 }));
 
-vi.mock('../../data/utils/logger', () => ({
+vi.mock('~~/settings/data/utils/logger', () => ({
   logMessage: vi.fn(),
 }));
 

--- a/settings/test/data/updateGetterValues.spec.ts
+++ b/settings/test/data/updateGetterValues.spec.ts
@@ -1,31 +1,31 @@
 import { globSync } from 'glob';
 import { describe, it, expect, vi } from 'vitest';
-import { updateGetterValues } from '../../data/updateGetterValues';
-import { GETTERS_REGEX_PATTERN, STORE_DIR, STORE_GETTERS_LIST_PATH } from '../../data/utils/constant';
-import { writeJsonFile } from '../../data/utils/json';
-import { updateList } from '../../data/utils/list';
-import { logMessage } from '../../data/utils/logger';
-import { extractValuesByRegex, getUniqueValues } from '../../data/utils/regex';
 import type { MockedFunction } from 'vitest';
+import { updateGetterValues } from '~~/settings/data/updateGetterValues';
+import { GETTERS_REGEX_PATTERN, STORE_DIR, STORE_GETTERS_LIST_PATH } from '~~/settings/data/utils/constant';
+import { writeJsonFile } from '~~/settings/data/utils/json';
+import { updateList } from '~~/settings/data/utils/list';
+import { logMessage } from '~~/settings/data/utils/logger';
+import { extractValuesByRegex, getUniqueValues } from '~~/settings/data/utils/regex';
 
 // モジュールのモックを設定します
 vi.mock('glob', () => ({
   globSync: vi.fn(),
 }));
 
-vi.mock('../../data/utils/json', () => ({
+vi.mock('~~/settings/data/utils/json', () => ({
   writeJsonFile: vi.fn(),
 }));
 
-vi.mock('../../data/utils/list', () => ({
+vi.mock('~~/settings/data/utils/list', () => ({
   updateList: vi.fn(),
 }));
 
-vi.mock('../../data/utils/logger', () => ({
+vi.mock('~~/settings/data/utils/logger', () => ({
   logMessage: vi.fn(),
 }));
 
-vi.mock('../../data/utils/regex', () => ({
+vi.mock('~~/settings/data/utils/regex', () => ({
   extractValuesByRegex: vi.fn(),
   getUniqueValues: vi.fn(),
 }));

--- a/settings/test/data/updateStateValues.spec.ts
+++ b/settings/test/data/updateStateValues.spec.ts
@@ -1,31 +1,31 @@
 import { globSync } from 'glob';
 import { describe, it, expect, vi } from 'vitest';
-import { updateStateValues } from '../../data/updateStateValues';
-import { STATE_REGEX_PATTERN, STORE_DIR, STORE_STATE_LIST_PATH } from '../../data/utils/constant';
-import { writeJsonFile } from '../../data/utils/json';
-import { updateList } from '../../data/utils/list';
-import { logMessage } from '../../data/utils/logger';
-import { extractValuesByRegex, getUniqueValues } from '../../data/utils/regex';
 import type { MockedFunction } from 'vitest';
+import { updateStateValues } from '~~/settings/data/updateStateValues';
+import { STATE_REGEX_PATTERN, STORE_DIR, STORE_STATE_LIST_PATH } from '~~/settings/data/utils/constant';
+import { writeJsonFile } from '~~/settings/data/utils/json';
+import { updateList } from '~~/settings/data/utils/list';
+import { logMessage } from '~~/settings/data/utils/logger';
+import { extractValuesByRegex, getUniqueValues } from '~~/settings/data/utils/regex';
 
 // モジュールのモックを設定します
 vi.mock('glob', () => ({
   globSync: vi.fn(),
 }));
 
-vi.mock('../../data/utils/json', () => ({
+vi.mock('~~/settings/data/utils/json', () => ({
   writeJsonFile: vi.fn(),
 }));
 
-vi.mock('../../data/utils/list', () => ({
+vi.mock('~~/settings/data/utils/list', () => ({
   updateList: vi.fn(),
 }));
 
-vi.mock('../../data/utils/logger', () => ({
+vi.mock('~~/settings/data/utils/logger', () => ({
   logMessage: vi.fn(),
 }));
 
-vi.mock('../../data/utils/regex', () => ({
+vi.mock('~~/settings/data/utils/regex', () => ({
   extractValuesByRegex: vi.fn(),
   getUniqueValues: vi.fn(),
 }));

--- a/settings/test/data/utils/file.spec.ts
+++ b/settings/test/data/utils/file.spec.ts
@@ -1,12 +1,12 @@
 import fs from 'fs';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { fileExists, readFile, writeFile, safeReadFile, safeWriteFile } from '../../../data/utils/file';
-import { handleError } from '../../../data/utils/logger';
 import type { MockedFunction } from 'vitest';
+import { fileExists, readFile, writeFile, safeReadFile, safeWriteFile } from '~~/settings/data/utils/file';
+import { handleError } from '~~/settings/data/utils/logger';
 
 // fs モジュールのモック
 vi.mock('fs');
-vi.mock('../../../data/utils/logger', () => ({
+vi.mock('~~/settings/data/utils/logger', () => ({
   handleError: vi.fn(),
 }));
 

--- a/settings/test/data/utils/json.spec.ts
+++ b/settings/test/data/utils/json.spec.ts
@@ -1,7 +1,7 @@
 import { format } from 'prettier';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { safeWriteFile } from '../../../data/utils/file';
-import { writeJsonFile } from '../../../data/utils/json'; // 実際のファイルパスに置き換えてください
+import { writeJsonFile } from '../../../data/utils/json';
 import { handleError } from '../../../data/utils/logger';
 import type { MockedFunction } from 'vitest';
 

--- a/settings/test/data/utils/json.spec.ts
+++ b/settings/test/data/utils/json.spec.ts
@@ -1,17 +1,17 @@
 import { format } from 'prettier';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { safeWriteFile } from '../../../data/utils/file';
-import { writeJsonFile } from '../../../data/utils/json';
-import { handleError } from '../../../data/utils/logger';
 import type { MockedFunction } from 'vitest';
+import { safeWriteFile } from '~~/settings/data/utils/file';
+import { writeJsonFile } from '~~/settings/data/utils/json';
+import { handleError } from '~~/settings/data/utils/logger';
 
 vi.mock('prettier', () => ({
   format: vi.fn(),
 }));
-vi.mock('../../../data/utils/file', () => ({
+vi.mock('~~/settings/data/utils/file', () => ({
   safeWriteFile: vi.fn(),
 }));
-vi.mock('../../../data/utils/logger', () => ({
+vi.mock('~~/settings/data/utils/logger', () => ({
   handleError: vi.fn(),
 }));
 

--- a/settings/test/data/utils/list.spec.ts
+++ b/settings/test/data/utils/list.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { updateList } from '../../../data/utils/list';
+import { updateList } from '~~/settings/data/utils/list';
 
 describe('settings/data/utils/list.ts', () => {
   describe('updateList', () => {

--- a/settings/test/data/utils/logger.spec.ts
+++ b/settings/test/data/utils/logger.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { logMessage, handleError } from '../../../data/utils/logger';
+import { logMessage, handleError } from '~~/settings/data/utils/logger';
 
 describe('settings/data/utils/logger.ts', () => {
   beforeEach(() => {

--- a/settings/test/data/utils/regex.spec.ts
+++ b/settings/test/data/utils/regex.spec.ts
@@ -9,7 +9,7 @@ import {
   extractValuesByRegex,
   filterGetterPropertyName,
   getUniqueValues,
-} from '~~/settings/data/utils/regex'; // 実際のファイルパスに置き換えてください
+} from '~~/settings/data/utils/regex';
 
 vi.mock('~~/settings/data/utils/file', () => ({
   safeReadFile: vi.fn(),

--- a/settings/test/data/utils/regex.spec.ts
+++ b/settings/test/data/utils/regex.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, type MockedFunction } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { STATE_REGEX_PATTERN, GETTERS_REGEX_PATTERN } from '../../../data/utils/constant';
 import { safeReadFile } from '../../../data/utils/file';
 import { logMessage } from '../../../data/utils/logger';
@@ -9,6 +9,7 @@ import {
   filterGetterPropertyName,
   getUniqueValues,
 } from '../../../data/utils/regex'; // 実際のファイルパスに置き換えてください
+import type { MockedFunction } from 'vitest';
 
 vi.mock('../../../data/utils/file', () => ({
   safeReadFile: vi.fn(),

--- a/settings/test/data/utils/regex.spec.ts
+++ b/settings/test/data/utils/regex.spec.ts
@@ -1,22 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { STATE_REGEX_PATTERN, GETTERS_REGEX_PATTERN } from '../../../data/utils/constant';
-import { safeReadFile } from '../../../data/utils/file';
-import { logMessage } from '../../../data/utils/logger';
+import type { MockedFunction } from 'vitest';
+import { STATE_REGEX_PATTERN, GETTERS_REGEX_PATTERN } from '~~/settings/data/utils/constant';
+import { safeReadFile } from '~~/settings/data/utils/file';
+import { logMessage } from '~~/settings/data/utils/logger';
 import {
   extractContentByRegex,
   filterStatePropertyName,
   extractValuesByRegex,
   filterGetterPropertyName,
   getUniqueValues,
-} from '../../../data/utils/regex'; // 実際のファイルパスに置き換えてください
-import type { MockedFunction } from 'vitest';
+} from '~~/settings/data/utils/regex'; // 実際のファイルパスに置き換えてください
 
-vi.mock('../../../data/utils/file', () => ({
+vi.mock('~~/settings/data/utils/file', () => ({
   safeReadFile: vi.fn(),
   writeJsonFile: vi.fn(),
 }));
 
-vi.mock('../../../data/utils/logger', () => ({
+vi.mock('~~/settings/data/utils/logger', () => ({
   logMessage: vi.fn(),
 }));
 describe('settings/data/utils/regex.ts', () => {

--- a/src/components/ui/button/Button.vue
+++ b/src/components/ui/button/Button.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-import { Primitive, type PrimitiveProps } from 'radix-vue';
+import { Primitive } from 'radix-vue';
 import { cn } from '@/lib/tailwind';
-import { type ButtonVariants, buttonVariants } from '.';
+import { buttonVariants } from '.';
+import type { ButtonVariants } from '.';
+import type { PrimitiveProps } from 'radix-vue';
 import type { HTMLAttributes } from 'vue';
 
 interface Props extends PrimitiveProps {

--- a/src/components/ui/button/index.ts
+++ b/src/components/ui/button/index.ts
@@ -1,4 +1,5 @@
-import { type VariantProps, cva } from 'class-variance-authority';
+import { cva } from 'class-variance-authority';
+import type { VariantProps } from 'class-variance-authority';
 
 export { default as Button } from './Button.vue';
 

--- a/src/lib/tailwind.ts
+++ b/src/lib/tailwind.ts
@@ -1,5 +1,6 @@
-import { type ClassValue, clsx } from 'clsx';
+import { clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+import type { ClassValue } from 'clsx';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));

--- a/src/test/testHelper.ts
+++ b/src/test/testHelper.ts
@@ -1,6 +1,7 @@
 import { mountSuspended } from '@nuxt/test-utils/runtime';
-import { createTestingPinia, type TestingPinia } from '@pinia/testing';
+import { createTestingPinia } from '@pinia/testing';
 import { mount, RouterLinkStub } from '@vue/test-utils';
+import type { TestingPinia } from '@pinia/testing';
 import type { Component } from 'vue';
 
 type InitialState = Record<string, unknown>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
  - 内部モジュールの参照方法と対応するテスト設定を統一し、コードベースの一貫性を向上しました。
  
- **Refactor**
  - 型定義とインポート宣言を整理し、コードの可読性および保守性を改善しました。
  
- **Tests**
  - テスト実行環境およびモック設定の調整により、一貫した検証プロセスを確保しました。  

これらの改善により、ユーザー体験には影響なく、全体の品質と安定性が向上しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->