### PR TITLE
`app.vue`と`default.vue`のテスト追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ describe('TestTargetComponentPath', () => {
 
   afterEach(() => {
     vi.resetAllMocks();
+    vi.restoreAllMocks();
   });
 
   describe('マウント時の初期表示', () => {

--- a/README.md
+++ b/README.md
@@ -190,3 +190,134 @@ const { foo: fooState } = storeToRefs(fooStore);
 4. `eslint.config.mjs`で有効化
 
 ご自身のプロジェクトに合わせて、必要に応じてルールをoffにしてください。
+
+## テスト実装の雛形
+
+### コンポーネントテスト実装例
+
+```ts
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import TestTargetComponent from '@/components/your/test/target/component/path.vue';
+import { useTestStore } from '@/store/your/test/store/path';
+import { bindTestingPinia, mountSuspendedComponent } from '@/test/testHelper';
+import type { TestingPinia } from '@pinia/testing';
+
+describe('TestTargetComponentPath', () => {
+  let pinia: TestingPinia;
+  let testStore: ReturnType<typeof useTestStore>;
+
+  beforeEach(() => {
+    pinia = bindTestingPinia();
+    testStore = useTestStore();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('マウント時の初期表示', () => {
+    it('コンポーネントが正しくマウントされるか', async () => {
+      const wrapper = await mountSuspendedComponent(TestTargetComponent, pinia);
+      expect(wrapper.exists()).toBe(true);
+    });
+  });
+
+  describe('Props', () => {
+    it('propsの値が正しく表示されるか', async () => {
+      const testProps = {
+        propsName: 'propsValue',
+      };
+      const wrapper = await mountSuspendedComponent(TestTargetComponent, pinia, { props: testProps });
+      expect(wrapper.exists()).toBe(true);
+      expect(wrapper.find('div').text()).toBe('propsValue');
+    });
+  });
+
+  describe('子コンポーネントの表示', () => {
+    it('子コンポーネントが正しくレンダリングされるか', async () => {
+      const ChildComponent = {
+        template: '<div></div>',
+      };
+      const stubs = { ChildComponent };
+      const wrapper = await mountSuspendedComponent(TestTargetComponent, pinia, { stubs });
+      expect(wrapper.findComponent(ChildComponent).exists()).toBe(true);
+    });
+
+    it('子コンポーネントに正しいpropsが渡されるか', async () => {
+      const ChildComponent = {
+        props: ['test'],
+        template: '<div></div>',
+      };
+      const stubs = { ChildComponent };
+      const wrapper = await mountSuspendedComponent(TestTargetComponent, pinia, { stubs });
+      expect(wrapper.findComponent(ChildComponent).props('test')).toBe('期待値');
+    });
+
+    it('複数ある同じ名前の子コンポーネントがレンダリングされているか', async () => {
+      const ButtonComponent = {
+        template: '<button></button>',
+      };
+      const stubs = { ButtonComponent };
+      const wrapper = await mountSuspendedComponent(TestTargetComponent, pinia, { stubs });
+
+      const buttons = wrapper.findAllComponents(ButtonComponent);
+      const firstButton = buttons[0];
+      const secondButton = buttons[1];
+
+      expect(firstButton.exists()).toBe(true);
+      expect(secondButton.exists()).toBe(true);
+    });
+  });
+
+  describe('イベント発火', () => {
+    it('ボタンクリック時にclickイベントが発火するか', async () => {
+      const wrapper = await mountSuspendedComponent(TestTargetComponent, pinia);
+      const target = wrapper.find('button');
+      await target.trigger('click');
+      expect(wrapper.emitted('click')).toHaveBeenCalledOnce();
+    });
+
+    it('ボタンクリック時にclickイベントが1回emitされる', async () => {
+      const wrapper = await mountSuspendedComponent(TestTargetComponent, pinia);
+      const target = wrapper.find('button');
+      await target.trigger('click');
+      expect(wrapper.emitted('click')).toHaveLength(1);
+    });
+  });
+
+  describe('Store', () => {
+    it('storeの値が正しく表示されるか', async () => {
+      testStore.testValue = 'test';
+      const wrapper = await mountSuspendedComponent(TestTargetComponent, pinia);
+      expect(wrapper.find('div').text()).toBe('test');
+    });
+
+    it('storeの値が変更されたときに表示が更新されるか', async () => {
+      testStore.testValue = 'test';
+      const wrapper = await mountSuspendedComponent(TestTargetComponent, pinia);
+      expect(wrapper.find('div').text()).toBe('test');
+      testStore.testValue = 'updated';
+      expect(wrapper.find('div').text()).toBe('updated');
+    });
+
+    it('storeの関数が正しく呼び出されるか', async () => {
+      const wrapper = await mountSuspendedComponent(TestTargetComponent, pinia);
+      const target = wrapper.find('button');
+      await target.trigger('click');
+      expect(testStore.testFunction).toHaveBeenCalled();
+    });
+  });
+});
+```
+
+### `vi.spyOn()` と `vi.fn()` の使い分け
+
+`vi.spyOn()` を使用するケース：
+
+- 既存の実装を保持したまま関数の呼び出しを監視したい場合
+- `mockImplementation()`で一時的に実装を上書きする場合も可能
+
+`vi.fn()` を使用するケース：
+
+- 完全に新しいモック実装に置き換えたい場合
+- テストケースごとに異なる振る舞いを定義したい場合

--- a/README.md
+++ b/README.md
@@ -268,6 +268,15 @@ describe('TestTargetComponentPath', () => {
       expect(firstButton.exists()).toBe(true);
       expect(secondButton.exists()).toBe(true);
     });
+
+    it('slotsのコンテンツが正しくレンダリングされるか', async () => {
+      const slots = {
+        default: () => h('div', { id: 'slot-test' }, [h('p', 'slot content')]),
+      };
+      const wrapper = await mountSuspendedComponent(TestTargetComponent, pinia, { slots });
+      expect(wrapper.find('#slot-test').exists()).toBe(true);
+      expect(wrapper.find('p').text()).toBe('slot content');
+    });
   });
 
   describe('イベント発火', () => {

--- a/src/test/testHelper.ts
+++ b/src/test/testHelper.ts
@@ -2,7 +2,7 @@ import { mountSuspended } from '@nuxt/test-utils/runtime';
 import { createTestingPinia } from '@pinia/testing';
 import { mount, RouterLinkStub } from '@vue/test-utils';
 import type { TestingPinia } from '@pinia/testing';
-import type { Component } from 'vue';
+import type { Component, Slots, VNode } from 'vue';
 
 type InitialState = Record<string, unknown>;
 type TestWrapper<T extends Component> = ReturnType<typeof mount<T>>;
@@ -11,6 +11,7 @@ type MountOptions = {
   attachTo?: Element | string;
   data?: Record<string, unknown>;
   props?: Record<string, unknown>;
+  slots?: Record<string, () => VNode | VNode[] | string> | Slots;
   shallow?: boolean;
   stubs?: Record<string, Component | boolean>;
   mocks?: Record<string, unknown>;
@@ -25,6 +26,7 @@ const DEFAULT_MOUNT_OPTIONS: MountOptions = {
   attachTo: undefined,
   data: {},
   props: {},
+  slots: {},
   shallow: false,
   stubs: DEFAULT_STUBS,
   mocks: {},
@@ -63,13 +65,14 @@ export function mountComponent(
   options: Partial<MountOptions> = DEFAULT_MOUNT_OPTIONS,
 ): TestWrapper<typeof component> {
   const mergedOptions = { ...DEFAULT_MOUNT_OPTIONS, ...options };
-  const { data, attachTo, props, shallow, stubs, mocks, options: additionalOptions } = mergedOptions;
+  const { data, attachTo, props, slots, shallow, stubs, mocks, options: additionalOptions } = mergedOptions;
 
   return mount(component, {
     ...additionalOptions,
     data: () => data,
     attachTo,
     props,
+    slots,
     shallow,
     global: {
       plugins: [testingPinia],
@@ -101,13 +104,14 @@ export async function mountSuspendedComponent(
   options: Partial<MountOptions> = DEFAULT_MOUNT_OPTIONS,
 ): Promise<SuspendedTestWrapper<typeof component>> {
   const mergedOptions = { ...DEFAULT_MOUNT_OPTIONS, ...options };
-  const { data, attachTo, props, shallow, stubs, mocks, options: additionalOptions } = mergedOptions;
+  const { data, attachTo, props, slots, shallow, stubs, mocks, options: additionalOptions } = mergedOptions;
 
   return await mountSuspended(component, {
     ...additionalOptions,
     data: () => data,
     attachTo,
     props,
+    slots,
     shallow,
     global: {
       plugins: [testingPinia],

--- a/src/test/testHelper.ts
+++ b/src/test/testHelper.ts
@@ -1,11 +1,10 @@
 import { mountSuspended } from '@nuxt/test-utils/runtime';
 import { createTestingPinia } from '@pinia/testing';
-import { mount, RouterLinkStub } from '@vue/test-utils';
+import { RouterLinkStub } from '@vue/test-utils';
 import type { TestingPinia } from '@pinia/testing';
 import type { Component, Slots, VNode } from 'vue';
 
 type InitialState = Record<string, unknown>;
-type TestWrapper<T extends Component> = ReturnType<typeof mount<T>>;
 type SuspendedTestWrapper<T extends Component> = Awaited<ReturnType<typeof mountSuspended<T>>>;
 type MountOptions = {
   attachTo?: Element | string;
@@ -43,45 +42,6 @@ export function bindTestingPinia(initialState: InitialState = {}): TestingPinia 
   return createTestingPinia({
     stubActions: false,
     initialState: { ...initialState },
-  });
-}
-
-/**
- * Vueコンポーネントをテスト用にマウントします
- *
- * @param component - テスト対象のVueコンポーネント
- * @param testingPinia - テスト用のPiniaインスタンス
- * @param options - マウントオプション
- * @returns マウントされたコンポーネントのラッパー
- *
- * @example
- * const wrapper = mountComponent(MyComponent, pinia, {
- *   props: { message: 'Hello' }
- * });
- */
-export function mountComponent(
-  component: Component,
-  testingPinia: TestingPinia,
-  options: Partial<MountOptions> = DEFAULT_MOUNT_OPTIONS,
-): TestWrapper<typeof component> {
-  const mergedOptions = { ...DEFAULT_MOUNT_OPTIONS, ...options };
-  const { data, attachTo, props, slots, shallow, stubs, mocks, options: additionalOptions } = mergedOptions;
-
-  return mount(component, {
-    ...additionalOptions,
-    data: () => data,
-    attachTo,
-    props,
-    slots,
-    shallow,
-    global: {
-      plugins: [testingPinia],
-      stubs: {
-        ...DEFAULT_STUBS,
-        ...stubs,
-      },
-      mocks: { ...mocks },
-    },
   });
 }
 

--- a/src/test/unit/app.nuxt.spec.ts
+++ b/src/test/unit/app.nuxt.spec.ts
@@ -1,0 +1,25 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import NuxtAppVue from '@/app.vue';
+import { bindTestingPinia, mountSuspendedComponent } from '@/test/testHelper';
+import type { TestingPinia } from '@pinia/testing';
+
+describe('src/app.vue', () => {
+  let pinia: TestingPinia;
+
+  beforeEach(() => {
+    pinia = bindTestingPinia();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  it('基本的なレイアウト構造が正しくレンダリングされるか', async () => {
+    const wrapper = await mountSuspendedComponent(NuxtAppVue, pinia, { shallow: true });
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.find('#nuxt-app-vue').exists()).toBe(true);
+    expect(wrapper.find('nuxt-route-announcer-stub').exists()).toBe(true);
+    expect(wrapper.find('nuxt-layout-stub').exists()).toBe(true);
+  });
+});

--- a/src/test/unit/components/features/sample/CounterDisplay.nuxt.spec.ts
+++ b/src/test/unit/components/features/sample/CounterDisplay.nuxt.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import CounterDisplay from '@/components/features/sample/CounterDisplay.vue';
-import { bindTestingPinia, mountComponent } from '@/test/testHelper';
+import { bindTestingPinia, mountSuspendedComponent } from '@/test/testHelper';
 import type { TestingPinia } from '@pinia/testing';
 
 describe('src/features/sample/components/CounterDisplay.vue', () => {
@@ -15,9 +15,9 @@ describe('src/features/sample/components/CounterDisplay.vue', () => {
     vi.restoreAllMocks();
   });
 
-  test('コンポーネントに渡されたPropsが適切に表示されていること', () => {
+  test('コンポーネントに渡されたPropsが適切に表示されていること', async () => {
     const testProps = { count: 999 };
-    const wrapper = mountComponent(CounterDisplay, pinia, { props: testProps });
+    const wrapper = await mountSuspendedComponent(CounterDisplay, pinia, { props: testProps });
     expect(wrapper.find('div').text()).toBe('counter: 999');
   });
 });

--- a/src/test/unit/components/features/sample/CounterDisplay.nuxt.spec.ts
+++ b/src/test/unit/components/features/sample/CounterDisplay.nuxt.spec.ts
@@ -12,6 +12,7 @@ describe('src/features/sample/components/CounterDisplay.vue', () => {
 
   afterEach(() => {
     vi.resetAllMocks();
+    vi.restoreAllMocks();
   });
 
   test('コンポーネントに渡されたPropsが適切に表示されていること', () => {

--- a/src/test/unit/components/features/sample/Title.nuxt.spec.ts
+++ b/src/test/unit/components/features/sample/Title.nuxt.spec.ts
@@ -16,6 +16,7 @@ describe('src/features/sample/components/Title.vue', () => {
 
   afterEach(() => {
     vi.resetAllMocks();
+    vi.restoreAllMocks();
   });
 
   test('isFetchingStateがtrueのとき、ローディング文言が表示されること', async () => {

--- a/src/test/unit/components/features/sample/Title.nuxt.spec.ts
+++ b/src/test/unit/components/features/sample/Title.nuxt.spec.ts
@@ -1,4 +1,3 @@
-import { flushPromises } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import Title from '@/components/features/sample/Title.vue';
 import { useSampleStore } from '@/store/sampleStore';
@@ -21,8 +20,8 @@ describe('src/features/sample/components/Title.vue', () => {
 
   test('isFetchingStateがtrueのとき、ローディング文言が表示されること', async () => {
     sampleStore.isFetching = true;
+    sampleStore.title = 'test';
     const wrapper = await mountSuspendedComponent(Title, pinia);
-    await flushPromises();
     expect(wrapper.find('p').text()).toBe('Loading...');
   });
 
@@ -30,7 +29,6 @@ describe('src/features/sample/components/Title.vue', () => {
     sampleStore.isFetching = false;
     sampleStore.title = 'test';
     const wrapper = await mountSuspendedComponent(Title, pinia);
-    await flushPromises();
     expect(wrapper.find('h1').text()).toBe('test');
   });
 

--- a/src/test/unit/components/template/Index.nuxt.spec.ts
+++ b/src/test/unit/components/template/Index.nuxt.spec.ts
@@ -1,16 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import Index from '@/components/template/sample/Index.vue';
-import { fetchTitle } from '@/services/get/sampleServices';
 import { useSampleStore } from '@/store/sampleStore';
 import { bindTestingPinia, mountSuspendedComponent } from '@/test/testHelper';
 import type { TestingPinia } from '@pinia/testing';
-
-vi.mock('@/services/get/sampleServices', () => ({
-  fetchTitle: vi.fn().mockResolvedValue({
-    ok: true,
-    json: () => Promise.resolve({ title: 'Mocked Title' }),
-  }),
-}));
 
 describe('src/features/sample/components/Index.vue', () => {
   let pinia: TestingPinia;
@@ -19,8 +11,6 @@ describe('src/features/sample/components/Index.vue', () => {
   beforeEach(() => {
     pinia = bindTestingPinia();
     sampleStore = useSampleStore();
-    sampleStore.updateTitle = vi.fn().mockResolvedValue({ title: 'Mocked Title' });
-    vi.mocked(fetchTitle).mockClear();
   });
 
   afterEach(() => {
@@ -30,10 +20,10 @@ describe('src/features/sample/components/Index.vue', () => {
 
   test('Titleコンポーネントがレンダリングされているか', async () => {
     const Title = {
-      template: '<h1>Mocked Title</h1>',
+      template: '<h1></h1>',
     };
     const stubs = { Title };
-    const wrapper = await mountSuspendedComponent(Index, pinia, { stubs });
+    const wrapper = await mountSuspendedComponent(Index, pinia, { stubs, shallow: true });
     expect(wrapper.findComponent(Title).exists()).toBe(true);
   });
 
@@ -42,7 +32,7 @@ describe('src/features/sample/components/Index.vue', () => {
       template: '<button></button>',
     };
     const stubs = { Button };
-    const wrapper = await mountSuspendedComponent(Index, pinia, { stubs });
+    const wrapper = await mountSuspendedComponent(Index, pinia, { stubs, shallow: true });
     const incrementButton = wrapper.findAllComponents(Button)[0];
     const decrementButton = wrapper.findAllComponents(Button)[1];
 
@@ -57,7 +47,7 @@ describe('src/features/sample/components/Index.vue', () => {
       template: '<button></button>',
     };
     const stubs = { Button };
-    const wrapper = await mountSuspendedComponent(Index, pinia, { stubs });
+    const wrapper = await mountSuspendedComponent(Index, pinia, { stubs, shallow: true });
     const incrementButton = wrapper.findAllComponents(Button)[0];
     await incrementButton.trigger('click');
     expect(sampleStore.count).toBe(1);
@@ -68,7 +58,7 @@ describe('src/features/sample/components/Index.vue', () => {
       template: '<button></button>',
     };
     const stubs = { Button };
-    const wrapper = await mountSuspendedComponent(Index, pinia, { stubs });
+    const wrapper = await mountSuspendedComponent(Index, pinia, { stubs, shallow: true });
     const decrementButton = wrapper.findAllComponents(Button)[1];
     await decrementButton.trigger('click');
     expect(sampleStore.count).toBe(-1);
@@ -80,7 +70,7 @@ describe('src/features/sample/components/Index.vue', () => {
       template: '<button></button>',
     };
     const stubs = { CounterDisplay };
-    const wrapper = await mountSuspendedComponent(Index, pinia, { stubs });
+    const wrapper = await mountSuspendedComponent(Index, pinia, { stubs, shallow: true });
     expect(wrapper.findComponent(CounterDisplay).props('count')).toBe(sampleStore.count);
   });
 });

--- a/src/test/unit/components/template/Index.nuxt.spec.ts
+++ b/src/test/unit/components/template/Index.nuxt.spec.ts
@@ -19,14 +19,13 @@ describe('src/features/sample/components/Index.vue', () => {
   beforeEach(() => {
     pinia = bindTestingPinia();
     sampleStore = useSampleStore();
-    vi.spyOn(sampleStore, 'increment');
-    vi.spyOn(sampleStore, 'decrement');
     sampleStore.updateTitle = vi.fn().mockResolvedValue({ title: 'Mocked Title' });
     vi.mocked(fetchTitle).mockClear();
   });
 
   afterEach(() => {
     vi.resetAllMocks();
+    vi.restoreAllMocks();
   });
 
   test('Titleコンポーネントがレンダリングされているか', async () => {

--- a/src/test/unit/layouts/default.nuxt.spec.ts
+++ b/src/test/unit/layouts/default.nuxt.spec.ts
@@ -1,0 +1,32 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import DefaultLayout from '@/layouts/default.vue';
+import { bindTestingPinia, mountSuspendedComponent } from '@/test/testHelper';
+import type { TestingPinia } from '@pinia/testing';
+
+describe('src/layouts/default.vue', () => {
+  let pinia: TestingPinia;
+
+  beforeEach(() => {
+    pinia = bindTestingPinia();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  it('コンポーネントが正しくレンダリングされるか', async () => {
+    const wrapper = await mountSuspendedComponent(DefaultLayout, pinia);
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.find('#nuxt-default-layout').exists()).toBe(true);
+  });
+
+  it('slotsのコンテンツが正しくレンダリングされるか', async () => {
+    const slots = {
+      default: () => h('div', { id: 'slot-test' }, [h('p', 'slot content')]),
+    };
+    const wrapper = await mountSuspendedComponent(DefaultLayout, pinia, { slots });
+    expect(wrapper.find('#slot-test').exists()).toBe(true);
+    expect(wrapper.find('p').text()).toBe('slot content');
+  });
+});


### PR DESCRIPTION
close #106 
close #107 

## やったこと

- READMEにテスト実装例を追加
- `default.vue`と`app.vue`のコンポーネントテストを追加
- mount用のヘルパー関数を`mountSuspended`を使用する方法に統一
- コンポーネントマウント時にslotsを受け取れるように機能追加
- `src/test/unit/components/template/Index.nuxt.spec.ts`単体のコンポーネントテストを実行するため、shallowを有効にする

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - READMEにコンポーネントテストの実装例とガイドラインを追加し、テスト環境のセットアップや各種検証方法を明示しました。
- **Tests**
  - 複数コンポーネントおよびレイアウトのテストケースを整理・強化し、レンダリングと状態管理の検証が向上しました。
  - 新しいテストスイートが追加され、コンポーネントの正しいレンダリングやスロットの内容が検証されるようになりました。
  - テストの設定とクリーンアップのプロセスが改善され、全体の信頼性が強化されています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->